### PR TITLE
Support for timeout when reading from socket

### DIFF
--- a/SwiftSocket/ysocket/ytcpsocket.swift
+++ b/SwiftSocket/ysocket/ytcpsocket.swift
@@ -32,7 +32,7 @@ import Foundation
 @asmname("ytcpsocket_connect") func c_ytcpsocket_connect(host:UnsafePointer<Int8>,port:Int32,timeout:Int32) -> Int32
 @asmname("ytcpsocket_close") func c_ytcpsocket_close(fd:Int32) -> Int32
 @asmname("ytcpsocket_send") func c_ytcpsocket_send(fd:Int32,buff:UnsafePointer<UInt8>,len:Int32) -> Int32
-@asmname("ytcpsocket_pull") func c_ytcpsocket_pull(fd:Int32,buff:UnsafePointer<UInt8>,len:Int32) -> Int32
+@asmname("ytcpsocket_pull") func c_ytcpsocket_pull(fd:Int32,buff:UnsafePointer<UInt8>,len:Int32,timeout:Int32) -> Int32
 @asmname("ytcpsocket_listen") func c_ytcpsocket_listen(addr:UnsafePointer<Int8>,port:Int32)->Int32
 @asmname("ytcpsocket_accept") func c_ytcpsocket_accept(onsocketfd:Int32,ip:UnsafePointer<Int8>,port:UnsafePointer<Int32>) -> Int32
 
@@ -126,10 +126,10 @@ public class TCPClient:YSocket{
     * read data with expect length
     * return success or fail with message
     */
-    public func read(expectlen:Int)->[UInt8]?{
+    public func read(expectlen:Int, timeout:Int = -1)->[UInt8]?{
         if let fd:Int32 = self.fd{
             var buff:[UInt8] = [UInt8](count:expectlen,repeatedValue:0x0)
-            var readLen:Int32=c_ytcpsocket_pull(fd, &buff, Int32(expectlen))
+            var readLen:Int32=c_ytcpsocket_pull(fd, &buff, Int32(expectlen), Int32(timeout))
             if readLen<=0{
                 return nil
             }


### PR DESCRIPTION
Add support for timeouts when reading data from socket. Timeout is 
specified with parameter 'timeout', time unit is seconds. Default
value is -1 which means no timeout (ie. no change in current behavior).