### PR TITLE
Moving to Swift 2.2: @asmname is @_silgen_name now

### DIFF
--- a/SwiftSocket/ysocket/ytcpsocket.swift
+++ b/SwiftSocket/ysocket/ytcpsocket.swift
@@ -29,12 +29,12 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
 import Foundation
 
-@asmname("ytcpsocket_connect") func c_ytcpsocket_connect(host:UnsafePointer<Int8>,port:Int32,timeout:Int32) -> Int32
-@asmname("ytcpsocket_close") func c_ytcpsocket_close(fd:Int32) -> Int32
-@asmname("ytcpsocket_send") func c_ytcpsocket_send(fd:Int32,buff:UnsafePointer<UInt8>,len:Int32) -> Int32
-@asmname("ytcpsocket_pull") func c_ytcpsocket_pull(fd:Int32,buff:UnsafePointer<UInt8>,len:Int32,timeout:Int32) -> Int32
-@asmname("ytcpsocket_listen") func c_ytcpsocket_listen(addr:UnsafePointer<Int8>,port:Int32)->Int32
-@asmname("ytcpsocket_accept") func c_ytcpsocket_accept(onsocketfd:Int32,ip:UnsafePointer<Int8>,port:UnsafePointer<Int32>) -> Int32
+@_silgen_name("ytcpsocket_connect") func c_ytcpsocket_connect(host:UnsafePointer<Int8>,port:Int32,timeout:Int32) -> Int32
+@_silgen_name("ytcpsocket_close") func c_ytcpsocket_close(fd:Int32) -> Int32
+@_silgen_name("ytcpsocket_send") func c_ytcpsocket_send(fd:Int32,buff:UnsafePointer<UInt8>,len:Int32) -> Int32
+@_silgen_name("ytcpsocket_pull") func c_ytcpsocket_pull(fd:Int32,buff:UnsafePointer<UInt8>,len:Int32,timeout:Int32) -> Int32
+@_silgen_name("ytcpsocket_listen") func c_ytcpsocket_listen(addr:UnsafePointer<Int8>,port:Int32)->Int32
+@_silgen_name("ytcpsocket_accept") func c_ytcpsocket_accept(onsocketfd:Int32,ip:UnsafePointer<Int8>,port:UnsafePointer<Int32>) -> Int32
 
 public class TCPClient:YSocket{
     /*

--- a/SwiftSocket/ysocket/yudpsocket.swift
+++ b/SwiftSocket/ysocket/yudpsocket.swift
@@ -30,13 +30,13 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import Foundation
 
-@asmname("yudpsocket_server") func c_yudpsocket_server(host:UnsafePointer<Int8>,port:Int32) -> Int32
-@asmname("yudpsocket_recive") func c_yudpsocket_recive(fd:Int32,buff:UnsafePointer<UInt8>,len:Int32,ip:UnsafePointer<Int8>,port:UnsafePointer<Int32>) -> Int32
-@asmname("yudpsocket_close") func c_yudpsocket_close(fd:Int32) -> Int32
-@asmname("yudpsocket_client") func c_yudpsocket_client() -> Int32
-@asmname("yudpsocket_get_server_ip") func c_yudpsocket_get_server_ip(host:UnsafePointer<Int8>,ip:UnsafePointer<Int8>) -> Int32
-@asmname("yudpsocket_sentto") func c_yudpsocket_sentto(fd:Int32,buff:UnsafePointer<UInt8>,len:Int32,ip:UnsafePointer<Int8>,port:Int32) -> Int32
-@asmname("enable_broadcast") func c_enable_broadcast(fd:Int32)
+@_silgen_name("yudpsocket_server") func c_yudpsocket_server(host:UnsafePointer<Int8>,port:Int32) -> Int32
+@_silgen_name("yudpsocket_recive") func c_yudpsocket_recive(fd:Int32,buff:UnsafePointer<UInt8>,len:Int32,ip:UnsafePointer<Int8>,port:UnsafePointer<Int32>) -> Int32
+@_silgen_name("yudpsocket_close") func c_yudpsocket_close(fd:Int32) -> Int32
+@_silgen_name("yudpsocket_client") func c_yudpsocket_client() -> Int32
+@_silgen_name("yudpsocket_get_server_ip") func c_yudpsocket_get_server_ip(host:UnsafePointer<Int8>,ip:UnsafePointer<Int8>) -> Int32
+@_silgen_name("yudpsocket_sentto") func c_yudpsocket_sentto(fd:Int32,buff:UnsafePointer<UInt8>,len:Int32,ip:UnsafePointer<Int8>,port:Int32) -> Int32
+@_silgen_name("enable_broadcast") func c_enable_broadcast(fd:Int32)
 
 public class UDPClient: YSocket {
     public override init(addr a:String,port p:Int){


### PR DESCRIPTION
**NOTE:
This PR should ONLY be merged when Xcode7.3 is released stable.**

Both yudpsocket.swift and ytcpsocket.swift won't compile with Swift 2.2 (Xcode 7.3 beta)

Compilation errors refer to Unknown attribute 'asmname', i.e.
/Users/ciukes/dev/MockJsonServerApp/scm/MockJsonServer/Frameworks/SwiftSocket/SwiftSocket/ysocket/ytcpsocket.swift:32:2: Unknown attribute 'asmname'

According to Apple dev forum: 
Swift 2.2 abruptly removed the @asmname attribute in favor of @_silgen_name.
https://forums.developer.apple.com/thread/31497

The same information confirmed elsewhere:
tidwall/SwiftWebSocket#28