### PR TITLE
Add support for listening to port 0

### DIFF
--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -35,8 +35,8 @@ public typealias Byte = UInt8
 open class Socket {
   
     public let address: String
-    public var port: Int32
-    public var fd: Int32?
+    internal(set) public var port: Int32
+    internal(set) public var fd: Int32?
   
     public init(address: String, port: Int32) {
         self.address = address

--- a/Sources/Socket.swift
+++ b/Sources/Socket.swift
@@ -35,7 +35,7 @@ public typealias Byte = UInt8
 open class Socket {
   
     public let address: String
-    public let port: Int32
+    public var port: Int32
     public var fd: Int32?
   
     public init(address: String, port: Int32) {

--- a/Sources/TCPClient.swift
+++ b/Sources/TCPClient.swift
@@ -36,6 +36,7 @@ import Foundation
 @_silgen_name("ytcpsocket_pull") private func c_ytcpsocket_pull(_ fd:Int32,buff:UnsafePointer<Byte>,len:Int32,timeout:Int32) -> Int32
 @_silgen_name("ytcpsocket_listen") private func c_ytcpsocket_listen(_ address:UnsafePointer<Int8>,port:Int32)->Int32
 @_silgen_name("ytcpsocket_accept") private func c_ytcpsocket_accept(_ onsocketfd:Int32,ip:UnsafePointer<Int8>,port:UnsafePointer<Int32>) -> Int32
+@_silgen_name("ytcpsocket_port") private func c_ytcpsocket_port(_ fd:Int32) -> Int32
 
 open class TCPClient: Socket {
   
@@ -143,6 +144,17 @@ open class TCPServer: Socket {
         let fd = c_ytcpsocket_listen(self.address, port: Int32(self.port))
         if fd > 0 {
             self.fd = fd
+            
+            // If port 0 is used, get the actual port number which the server is listening to
+            if (self.port == 0) {
+                let p = c_ytcpsocket_port(fd)
+                if (p == -1) {
+                    return .failure(SocketError.unknownError)
+                } else {
+                    self.port = p
+                }
+            }
+            
             return .success
         } else {
             return .failure(SocketError.unknownError)

--- a/Sources/ytcpsocket.c
+++ b/Sources/ytcpsocket.c
@@ -173,3 +173,14 @@ int ytcpsocket_accept(int onsocketfd, char *remoteip, int *remoteport) {
         return -1;
     }
 }
+
+//return socket port
+int ytcpsocket_port(int socketfd) {
+    struct sockaddr_in sin;
+    socklen_t len = sizeof(sin);
+    if (getsockname(socketfd, (struct sockaddr *)&sin, &len) == -1) {
+        return -1;
+    } else {
+        return ntohs(sin.sin_port);
+    }
+}


### PR DESCRIPTION
"...asking to bind TCP on port 0 indicates a request to dynamically generate an unused port number. In other words, the port number you're actually listening on after that request is not zero."<sup>1</sup>

This pull request checks if `TCPServer.listen` is called with port 0. If it's true, [`getsockname`](http://man7.org/linux/man-pages/man2/getsockname.2.html) will be called to obtain the actual port number.

[1] http://unix.stackexchange.com/questions/180492/is-it-possible-to-connect-to-tcp-port-0