### PR TITLE
Add an `isBlocking` parameter to the `connect` method

### DIFF
--- a/Sources/TCPClient.swift
+++ b/Sources/TCPClient.swift
@@ -30,7 +30,7 @@
 
 import Foundation
 
-@_silgen_name("ytcpsocket_connect") private func c_ytcpsocket_connect(_ host:UnsafePointer<Byte>,port:Int32,timeout:Int32) -> Int32
+@_silgen_name("ytcpsocket_connect") private func c_ytcpsocket_connect(_ host:UnsafePointer<Byte>,port:Int32,timeout:Int32,isBlocking:Int32) -> Int32
 @_silgen_name("ytcpsocket_close") private func c_ytcpsocket_close(_ fd:Int32) -> Int32
 @_silgen_name("ytcpsocket_send") private func c_ytcpsocket_send(_ fd:Int32,buff:UnsafePointer<Byte>,len:Int32) -> Int32
 @_silgen_name("ytcpsocket_pull") private func c_ytcpsocket_pull(_ fd:Int32,buff:UnsafePointer<Byte>,len:Int32,timeout:Int32) -> Int32
@@ -44,8 +44,8 @@ open class TCPClient: Socket {
      * connect to server
      * return success or fail with message
      */
-    open func connect(timeout: Int) -> Result {
-        let rs: Int32 = c_ytcpsocket_connect(self.address, port: Int32(self.port), timeout: Int32(timeout))
+    open func connect(timeout: Int, isBlocking: Bool = false) -> Result {
+        let rs: Int32 = c_ytcpsocket_connect(self.address, port: Int32(self.port), timeout: Int32(timeout), isBlocking: Int32(isBlocking ? 1 : 0))
         if rs > 0 {
             self.fd = rs
             return .success

--- a/Sources/ytcpsocket.c
+++ b/Sources/ytcpsocket.c
@@ -56,7 +56,7 @@ void ytcpsocket_set_block(int socket, int on) {
     }
 }
 
-int ytcpsocket_connect(const char *host, int port, int timeout) {
+int ytcpsocket_connect(const char *host, int port, int timeout, int isBlocking) {
     struct sockaddr_in sa;
     struct hostent *hp;
     int sockfd = -1;
@@ -69,7 +69,7 @@ int ytcpsocket_connect(const char *host, int port, int timeout) {
     sa.sin_family = hp->h_addrtype;
     sa.sin_port = htons(port);
     sockfd = socket(hp->h_addrtype, SOCK_STREAM, 0);
-    ytcpsocket_set_block(sockfd,0);
+    ytcpsocket_set_block(sockfd, isBlocking);
     connect(sockfd, (struct sockaddr *)&sa, sizeof(sa));
     fd_set fdwrite;
     struct timeval  tvSelect;


### PR DESCRIPTION
Add blocking socket connections support.

Example:

```
switch client.connect(timeout: defaultTimeout, isBlocking: true) {
  ...
}
```

By default socket connections are non-blocking as previously.