### PR TITLE
Disabling SIGPIPE errors on UDP Client.

### DIFF
--- a/Sources/yudpsocket.c
+++ b/Sources/yudpsocket.c
@@ -95,6 +95,10 @@ int yudpsocket_client() {
     int socketfd = socket(AF_INET, SOCK_DGRAM, 0);
     int reuseon = 1;
     setsockopt(socketfd, SOL_SOCKET, SO_REUSEADDR, &reuseon, sizeof(reuseon));
+
+    //disable SIGPIPE as we'll handle send errors ourselves
+    int noSigPipe = 1;
+    setsockopt(socketfd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof(noSigPipe));
   
     return socketfd;
 }


### PR DESCRIPTION
I've been using this library in some production code, and my Bug logging software has been picking up a lot of SIGPIPE 13 errors from this library on sends.

It looks in part due to the socket unexpectedly closing on our side (I was keeping the connection open for far too long), but given that the code has inbuilt error checking on the SendTo operation, it should be safe to disable the SIGPIPE errors in this way.