### PR TITLE
Use void keyword to suppress warning 

### DIFF
--- a/Sources/yudpsocket.c
+++ b/Sources/yudpsocket.c
@@ -40,12 +40,12 @@
 
 //return socket fd
 int yudpsocket_server(const char *address, int port) {
-  
+
     //create socket
     int socketfd=socket(AF_INET, SOCK_DGRAM, 0);
     int reuseon = 1;
     int r = -1;
-  
+
     //bind
     struct sockaddr_in serv_addr;
     memset( &serv_addr, '\0', sizeof(serv_addr));
@@ -60,11 +60,11 @@ int yudpsocket_server(const char *address, int port) {
         serv_addr.sin_addr.s_addr = inet_addr(address);
         serv_addr.sin_port = htons(port);
     }
-  
+
     if (r == -1) {
        return -1;
     }
-  
+
     r = bind(socketfd, (struct sockaddr *) &serv_addr, sizeof(serv_addr));
     if (r == 0) {
         return socketfd;
@@ -81,7 +81,7 @@ int yudpsocket_recive(int socket_fd, char *outdata, int expted_len, char *remote
     char *clientip = inet_ntoa(cli_addr.sin_addr);
     memcpy(remoteip, clientip, strlen(clientip));
     *remoteport = cli_addr.sin_port;
-  
+
     return len;
 }
 
@@ -90,7 +90,7 @@ int yudpsocket_close(int socket_fd) {
 }
 
 //return socket fd
-int yudpsocket_client() {
+int yudpsocket_client(void) {
     //create socket
     int socketfd = socket(AF_INET, SOCK_DGRAM, 0);
     int reuseon = 1;
@@ -99,7 +99,7 @@ int yudpsocket_client() {
     //disable SIGPIPE as we'll handle send errors ourselves
     int noSigPipe = 1;
     setsockopt(socketfd, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, sizeof(noSigPipe));
-  
+
     return socketfd;
 }
 
@@ -112,16 +112,16 @@ void enable_broadcast(int socket_fd) {
 int yudpsocket_get_server_ip(char *host, char *ip) {
     struct hostent *hp;
     struct sockaddr_in address;
-  
+
     hp = gethostbyname(host);
     if (hp == NULL) {
         return -1;
     }
-  
+
     bcopy((char *)hp->h_addr, (char *)&address.sin_addr, hp->h_length);
     char *clientip = inet_ntoa(address.sin_addr);
     memcpy(ip, clientip, strlen(clientip));
-  
+
     return 0;
 }
 
@@ -134,6 +134,6 @@ int yudpsocket_sentto(int socket_fd, char *msg, int len, char *toaddr, int topot
     address.sin_port = htons(topotr);
     address.sin_addr.s_addr = inet_addr(toaddr);
     int sendlen = (int)sendto(socket_fd, msg, len, 0, (struct sockaddr *)&address, addrlen);
-  
+
     return sendlen;
 }


### PR DESCRIPTION
This patch suppresses warning "This old-style function definition is not preceded by a prototype".

![image](https://user-images.githubusercontent.com/22689/118358502-11140000-b5ba-11eb-8ab9-6631729f505a.png)
